### PR TITLE
Fix handling of optional inputs without a value

### DIFF
--- a/src/main/java/fr/insalyon/creatis/moteurlite/MoteurLiteConstants.java
+++ b/src/main/java/fr/insalyon/creatis/moteurlite/MoteurLiteConstants.java
@@ -3,4 +3,6 @@ package fr.insalyon.creatis.moteurlite;
 public class MoteurLiteConstants {
     
     public static final String RESULTS_DIRECTORY = "results-directory";
+    // This must match the similar constant in VIP-portal
+    public static final String INPUT_WITHOUT_VALUE = "No_value_provided";
 }

--- a/src/main/java/fr/insalyon/creatis/moteurlite/runner/JobSubmitter.java
+++ b/src/main/java/fr/insalyon/creatis/moteurlite/runner/JobSubmitter.java
@@ -101,10 +101,15 @@ public class JobSubmitter extends Thread {
 
         for (String inputId : invocationInputs.keySet()) {
             String value = invocationInputs.get(inputId);
-            Input.Type type = boutiquesInputs.get(inputId).getType();
+            Input input = boutiquesInputs.get(inputId);
+            Input.Type type = input.getType();
 
+            if (input.getOptional() != null && input.getOptional() &&
+                    value.equals(MoteurLiteConstants.INPUT_WITHOUT_VALUE)) {
+                continue; // optional input with no value, skip it
+            }
             if (type == Input.Type.NUMBER) {
-                if (boutiquesInputs.get(inputId).getInteger() != null && boutiquesInputs.get(inputId).getInteger()) {
+                if (input.getInteger() != null && input.getInteger()) {
                     jsonNode.put(inputId, Integer.parseInt(value));
                 } else {
                     jsonNode.put(inputId, Float.parseFloat(value));


### PR DESCRIPTION
When handling optional inputs of type Number of Boolean, and when no value is provided, VIP-portal passes the magic string `No_value_provided` as content. Moteurlite then tries to parse this string as an Int/Float/Boolean to generate the invocation file, and parsing fails.
This patch fixes this by just skipping optional inputs when their content is `No_value_provided`.
