### PR TITLE
Replace spaces with underscores in jobId

### DIFF
--- a/src/main/java/fr/insalyon/creatis/moteurlite/runner/JobSubmitter.java
+++ b/src/main/java/fr/insalyon/creatis/moteurlite/runner/JobSubmitter.java
@@ -70,7 +70,8 @@ public class JobSubmitter extends Thread {
                 }
 
                 String invocationString = convertMapToJson(finalInvocationInputs, boutiquesInputs);
-                String jobId = applicationName + "-" + System.nanoTime() + ".sh";
+                // jobId can be used for filenames, so normalize it by removing spaces
+                String jobId = applicationName.replace(' ', '_') + "-" + System.nanoTime() + ".sh";
     
                 submit(new GaswInput(applicationName, applicationName + ".json", downloads, resultsDirectoryURI, invocationString, jobId));
             }


### PR DESCRIPTION
Moteurlite generates a `jobId` string base on the boutiques descriptor application name, which can contain spaces.
The `jobId` is then used in GASW&plugins to create a number of filenames, where having spaces increases the likelihood of issues due to improper quoting/parsing.

This patch updates the `jobId` generation to replace spaces with underscores, assuming the other problematic characters in an appname have already been checked by the import process. This is similar to what VIP-portal does in `AppVersion.java:getDescriptorFilename()`.