### PR TITLE
Fix optional file inputs

### DIFF
--- a/src/main/java/fr/insalyon/creatis/moteurlite/runner/JobSubmitter.java
+++ b/src/main/java/fr/insalyon/creatis/moteurlite/runner/JobSubmitter.java
@@ -61,9 +61,13 @@ public class JobSubmitter extends Thread {
                     } else {
                         if (Input.Type.FILE.equals(boutiquesInputs.get(inputId).getType())) {
                             URI downloadURI = getURI(inputValue);
-                            String filename = Paths.get(downloadURI.getPath()).getFileName().toString();
-                            downloads.add(downloadURI);
-                            inputValue = filename;
+                            if (downloadURI.getPath() == null) {
+                              logger.info("Skipping download for file input with no path: " + inputId + "=" + inputValue);
+                            } else {
+                               String filename = Paths.get(downloadURI.getPath()).getFileName().toString();
+                               downloads.add(downloadURI);
+                               inputValue = filename;
+                            }
                         }
                         finalInvocationInputs.put(inputId, inputValue);
                     }
@@ -105,9 +109,16 @@ public class JobSubmitter extends Thread {
             Input input = boutiquesInputs.get(inputId);
             Input.Type type = input.getType();
 
-            if (input.getOptional() != null && input.getOptional() &&
-                    value.equals(MoteurLiteConstants.INPUT_WITHOUT_VALUE)) {
-                continue; // optional input with no value, skip it
+            if (input.getOptional() != null && input.getOptional()) {
+                String testValue = value;
+                // for file inputs, ignore any colon-based prefix (such as "file:", "lfn:")
+                if (type == Input.Type.FILE) {
+                    testValue = value.replaceFirst("[^:]*:","");
+                }
+                // skip optional inputs with no value
+                if(testValue.equals(MoteurLiteConstants.INPUT_WITHOUT_VALUE)) {
+                    continue;
+                }
             }
             if (type == Input.Type.NUMBER) {
                 if (input.getInteger() != null && input.getInteger()) {


### PR DESCRIPTION
This is a quick/temporary fix allowing support for optional file inputs, until we switch from `inputs.xml` to `inputs.json` and no longer need the `No_value_provided` magic value.

- Fix NPE in `JobSubmitter.java:createJobs()` for file inputs that parse as URIs but have `getPath()` returning null, such as `file:No_value_provided` or `lfn:No_value_provided`.
- Fix the magic value test for optional file inputs by ignoring the colon-based prefix. Previous testing of optional values added in #15 did not account for the possible prefix, causing such inputs to end up in the invocation file.


